### PR TITLE
Avoid recursive cppstats dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,10 @@
 
 
 from setuptools import setup, find_packages
-import cppstats
 
 setup(
     name='cppstats',
-    version=cppstats.version(),
+    version="0.9.0",
     packages=find_packages(exclude=['scripts']),
     url='http://www.fosd.net/cppstats',
     license='LGPLv3',


### PR DESCRIPTION
Querying the cppstats version number in setup.py by
importing cppstats requires that all dependencies
are installed before installation, thus effectively
defeating automatic dependency management -- everything
has to be install by hand before.