### PR TITLE
Update README, dependencies, and srcML

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,6 +36,7 @@ Current tested version of srcML:
     sudo apt-get install xsltproc  # XSLT 1.0 command line processor
     sudo apt-get install libxml2 libxml2-dev  # library for processing XML
     sudo apt-get install gcc  # GNU compiler collection
+    sudo apt-get install python-dev libxml2-dev libxslt-dev # cppstats setuptools builds some dependencies from scratch, so these development packages are required
     ```
 
     - download and install srcML libraries

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,25 +40,8 @@ Current tested version of srcML:
     ```
 
     - download and install srcML libraries
-
-        - download a binary package that is sufficient for you and your platform from: http://www.srcml.org/downloads.html
-        - put the srcML binaries into your `$PATH` (so it can be called directly via "src2srcml" and "srcml2src")
-
-        - if using 32-bit srcML libraries on an 64-bit platform
-
-            ```bash
-            sudo apt-get install ia32-libs  # 32bit compatibility libs (only on 64bit system needed)
-            sudo apt-get install libarchive12:i386  # libarchive 32bit for linking with srcML libs (12.04)
-            # or libarchive13:i386 if that one is current version (14.04)
-            ```
-
-        - if using an old srcML version on an up-to-date system
-
-            - make soft links for updated libraries used by srcML, e.g.:
-
-                ```bash
-                sudo ln -s /usr/lib/i386-linux-gnu/libarchive.so.12 /usr/lib/i386-linux-gnu/libarchive.so.2
-                ```
+        - download the deb binary package that is sufficient for your platform from: http://www.srcml.org/downloads.html
+        - install the deb package; srcml is available from the command line via 'srcml'
 
 3. install Python package for cppstats and defined Python dependencies
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,12 +13,12 @@ In detail, cppstats was successfully tested under:
 
 - Ubuntu 12.04 64-bit, Python 2.7.3,
 - Ubuntu 14.04 64-bit, Python 2.7.6, and
-- Cygwin 64-bit, Python 2.7.3.
+- Cygwin 64-bit, Python 2.7.3 and Python 2.10.3.
 
 Right now, Python 3.x is NOT supported.
 
 Current tested version of srcML:
-`Trunk 19109c Thu May 22 09:18:31 2014 -0400`
+`srcML Beta (v0.9.5)`
 
 
 ## xUBUNTU

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -151,10 +151,10 @@ CYGWIN
 
 4. supply cppstats with the appropriate paths in `cppstats_input.txt`
 
-    * use cygwin-paths like `/cygdrive/c/Users/user/data/mpsolve/mpsolve-2.2`
+    * use relative paths like `data/mpsolve/mpsolve-2.2` and call cppstats relation to these given paths
     * each project folder given in the file has to be structured as follows:
 
         ```
-        > /cygdrive/c/Users/user/data/mpsolve/mpsolve-2.2
+        > data/mpsolve/mpsolve-2.2
             > source/ (here are the C source files)
         ```

--- a/cppstats/cppstats.py
+++ b/cppstats/cppstats.py
@@ -49,7 +49,7 @@ import cli, preparation, analysis
 # #################################################
 # version number
 
-__version__ = "v0.9.1"
+__version__ = "v0.9.2"
 
 def version() :
     return "cppstats " + __version__

--- a/cppstats/preparation.py
+++ b/cppstats/preparation.py
@@ -133,13 +133,13 @@ def silentlyRemoveFile(filename):
 
 
 def src2srcml(src, srcml):
-    __s2sml = "src2srcml"
+    __s2sml = "srcml"
     runBashCommand([__s2sml, src, "--language=C"], stdout=open(srcml, 'w+'))  # + " -o " + srcml)
     # FIXME incorporate "|| rm ${f}.xml" from bash
 
 
 def srcml2src(srcml, src):
-    __sml2s = "srcml2src"
+    __sml2s = "srcml"
     runBashCommand([__sml2s, srcml], stdout=open(src, 'w+'))  # + " -o " + src)
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cppstats',
-    version="0.9.1",
+    version="0.9.2",
     packages=find_packages(exclude=['scripts']),
     url='http://www.fosd.net/cppstats',
     license='LGPLv3',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
 
     dependency_links=[
-        'https://github.com/Ext3h/python-statlib/archive/release-1.2.tar.gz#egg=statlib-1.2'
+        'https://github.com/clhunsen/python-statlib/archive/release-1.2.tar.gz#egg=statlib-1.2'
     ],
 
     entry_points={'console_scripts': [


### PR DESCRIPTION
Some updates on the install notes:
- update to most recent version of srcml (0.9.5)
- fix install dependencies for ubuntu systems
- remove notes on 32-bit installation, as there are 64-bit binaries now available
